### PR TITLE
Make the clickable refresh link optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-outcomes-error-alert",
   "description": "Error alert displayed in outcomes FRAs",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run clean -s",

--- a/src/ErrorAlert.js
+++ b/src/ErrorAlert.js
@@ -41,12 +41,17 @@ class ErrorAlert extends React.Component {
 			return null;
 		}
 
+		let refresh = 'refresh the page';
+		if ( this.props.refresh ) {
+			refresh = <a className='refresh-link' onClick={this.props.refresh}>{refresh}</a>;
+		}
+
 		if ( this.state.errorType === ErrorTypes.SERVER_ERROR ) {
 			return (
 				<ErrorFloatingContainer>
 					<div className='server-error'>
 						<div>
-							<strong>Oops!</strong> We're having trouble connecting you. You might want to <a className='refresh-link' onClick={this.props.refresh}>refresh the page</a>, or try again later.
+							<strong>Oops!</strong> We're having trouble connecting you. You might want to {refresh}, or try again later.
 						</div>
 					</div>
 				</ErrorFloatingContainer>
@@ -69,7 +74,7 @@ class ErrorAlert extends React.Component {
 }
 
 ErrorAlert.propTypes = {
-	refresh: React.PropTypes.func.isRequired
+	refresh: React.PropTypes.func
 };
 
 export default ErrorAlert;


### PR DESCRIPTION
Make the clickable refresh link optional- if no `refresh` function is provided, the "refresh the page" text is just normal text instead of a clickable link.